### PR TITLE
Use qgis repositories to get latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Julien ANCELIN
 
 ENV LANG C.UTF-8
 
-RUN echo "deb http://qgis.org/debian-ltr xenial main" >> /etc/apt/sources.list
+RUN echo "deb http://qgis.org/debian xenial main" >> /etc/apt/sources.list
 RUN gpg --keyserver keyserver.ubuntu.com --recv CAEB3DC3BDF7FB45
 RUN gpg --export --armor CAEB3DC3BDF7FB45 | apt-key add -
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ RUN apt-get install -y gnupg apt-transport-https ca-certificates
 RUN echo "deb http://qgis.org/debian xenial main" >> /etc/apt/sources.list
 RUN gpg --keyserver keyserver.ubuntu.com --recv CAEB3DC3BDF7FB45
 RUN gpg --export --armor CAEB3DC3BDF7FB45 | apt-key add -
+
+# add qgis repositories for ltr
+RUN wget -O - https://qgis.org/downloads/qgis-2017.gpg.key | gpg --import
+RUN gpg --fingerprint CAEB3DC3BDF7FB45  |
+RUN echo "deb     https://qgis.org/ubuntu-ltr xenial main" >> /etc/apt/sources.list
+
+
 RUN apt-get update && \
     apt-get install -y qgis python-qgis qgis-plugin-grass \
     locales locales-all && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER Julien ANCELIN
 
 ENV LANG C.UTF-8
 
+RUN apt-get -y update
+RUN apt-get install -y gnupg apt-transport-https ca-certificates
+
 RUN echo "deb http://qgis.org/debian xenial main" >> /etc/apt/sources.list
 RUN gpg --keyserver keyserver.ubuntu.com --recv CAEB3DC3BDF7FB45
 RUN gpg --export --armor CAEB3DC3BDF7FB45 | apt-key add -

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ RUN gpg --keyserver keyserver.ubuntu.com --recv CAEB3DC3BDF7FB45
 RUN gpg --export --armor CAEB3DC3BDF7FB45 | apt-key add -
 
 # add qgis repositories for ltr
+RUN apt-get update && \
+    apt-get install wget
+
 RUN wget -O - https://qgis.org/downloads/qgis-2017.gpg.key | gpg --import
-RUN gpg --fingerprint CAEB3DC3BDF7FB45  |
+RUN gpg --fingerprint CAEB3DC3BDF7FB45  
 RUN echo "deb     https://qgis.org/ubuntu-ltr xenial main" >> /etc/apt/sources.list
 
 


### PR DESCRIPTION
Hi Julien, 
A small improvement to build images using qgis.org ppa for using a more up to date version of qgis ltr. I didn't add the ubuntugis dependencies by now. 
Et bonne année!