### PR TITLE
Use qgis repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ RUN apt-get install -y gnupg apt-transport-https ca-certificates
 RUN echo "deb http://qgis.org/debian xenial main" >> /etc/apt/sources.list
 RUN gpg --keyserver keyserver.ubuntu.com --recv CAEB3DC3BDF7FB45
 RUN gpg --export --armor CAEB3DC3BDF7FB45 | apt-key add -
+
+# add qgis repositories for ltr
+RUN wget -O - https://qgis.org/downloads/qgis-2017.gpg.key | gpg --import
+RUN gpg --fingerprint CAEB3DC3BDF7FB45  |
+RUN echo "deb     https://qgis.org/ubuntu-ltr xenial main" >> /etc/apt/sources.list
+
+
 RUN apt-get update && \
     apt-get install -y qgis python-qgis qgis-plugin-grass \
     locales locales-all && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ RUN gpg --keyserver keyserver.ubuntu.com --recv CAEB3DC3BDF7FB45
 RUN gpg --export --armor CAEB3DC3BDF7FB45 | apt-key add -
 
 # add qgis repositories for ltr
+RUN apt-get update && \
+    apt-get install wget
+
 RUN wget -O - https://qgis.org/downloads/qgis-2017.gpg.key | gpg --import
-RUN gpg --fingerprint CAEB3DC3BDF7FB45  |
+RUN gpg --fingerprint CAEB3DC3BDF7FB45  
 RUN echo "deb     https://qgis.org/ubuntu-ltr xenial main" >> /etc/apt/sources.list
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,19 @@ RUN echo "deb http://qgis.org/debian xenial main" >> /etc/apt/sources.list
 RUN gpg --keyserver keyserver.ubuntu.com --recv CAEB3DC3BDF7FB45
 RUN gpg --export --armor CAEB3DC3BDF7FB45 | apt-key add -
 
+# add ubuntugis ppa for a recent enough gdal
+
+RUN echo "deb http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu xenial main" >> /etc/apt/sources.list
+
+RUN  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 314DF160
+
 # add qgis repositories for ltr
 RUN apt-get update && \
     apt-get install wget
 
 RUN wget -O - https://qgis.org/downloads/qgis-2017.gpg.key | gpg --import
-RUN gpg --fingerprint CAEB3DC3BDF7FB45  
-RUN echo "deb     https://qgis.org/ubuntu-ltr xenial main" >> /etc/apt/sources.list
+RUN gpg --fingerprint CAEB3DC3BDF7FB45
+RUN echo "deb     https://qgis.org/ubuntugis-ltr xenial main" >> /etc/apt/sources.list
 
 
 RUN apt-get update && \


### PR DESCRIPTION
finally I had to add ubuntugis-unstable dependencies because gpkg was not supported in the very old gdal 1.1 still in xenial repos :)